### PR TITLE
added num image recomputation on slotchange

### DIFF
--- a/demo/image-carousel-demo-app.html
+++ b/demo/image-carousel-demo-app.html
@@ -1,16 +1,16 @@
-<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../image-carousel.html">
-<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../polymer/lib/elements/dom-repeat.html">
 <dom-module id="image-carousel-demo-app">
   <template>
     <style>
     </style>
     <div>
-        <image-carousel id="my-carousel" aria-label="actual image-carousel">
-            <template slot="images" is="dom-repeat" items='[[images]]'>
-                <img class="scrolling-images" src="[[item]]" alt$="demo alt [[index]]" width="100px" height="350px">
-            </template>
-        </image-carousel>
+      <image-carousel id="my-carousel" aria-label="actual image-carousel">
+        <template slot="images" is="dom-repeat" items='[[images]]'>
+          <img class="scrolling-images" src="[[item]]" alt$="demo alt [[index]]" width="100px" height="350px">
+        </template>
+      </image-carousel>
     </div>
   </template>
 
@@ -20,10 +20,8 @@
       static get properties() {
         return {
           // used to pass in images for the dom-repeat
-          images: {
-            type: Array
-            }
-          }
+          images: Array
+        };
       }
     }
     window.customElements.define(ImageCarouselDemoApp.is, ImageCarouselDemoApp);

--- a/demo/image-carousel-demo-app.html
+++ b/demo/image-carousel-demo-app.html
@@ -1,0 +1,31 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../image-carousel.html">
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<dom-module id="image-carousel-demo-app">
+  <template>
+    <style>
+    </style>
+    <div>
+        <image-carousel id="my-carousel" aria-label="actual image-carousel">
+            <template slot="images" is="dom-repeat" items='[[images]]'>
+                <img class="scrolling-images" src="[[item]]" alt$="demo alt [[index]]" width="100px" height="350px">
+            </template>
+        </image-carousel>
+    </div>
+  </template>
+
+  <script>
+    class ImageCarouselDemoApp extends Polymer.Element {
+      static get is() { return 'image-carousel-demo-app'; }
+      static get properties() {
+        return {
+          // used to pass in images for the dom-repeat
+          images: {
+            type: Array
+            }
+          }
+      }
+    }
+    window.customElements.define(ImageCarouselDemoApp.is, ImageCarouselDemoApp);
+  </script>
+</dom-module>

--- a/demo/image-carousel-demo-app.html
+++ b/demo/image-carousel-demo-app.html
@@ -1,6 +1,6 @@
-<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="../image-carousel.html">
-<link rel="import" href="../polymer/lib/elements/dom-repeat.html">
 <dom-module id="image-carousel-demo-app">
   <template>
     <style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,7 @@
     <link rel="import" href="../../polymer/lib/elements/dom-bind.html">
     <link rel="import" href="../../polymer/lib/elements/custom-style.html">
     <link rel="import" href="../image-carousel.html">
+    <link rel="import" href="./image-carousel-demo-app.html">
 
     <link rel="import" href="../../polymer/polymer-element.html">
     <link rel="import" href="../../iron-icons/iron-icons.html">
@@ -25,6 +26,9 @@
     <custom-style>
       <style is="custom-style" include="demo-pages-shared-styles">
         image-carousel:nth-child(odd) {
+          display: none;
+        }
+        image-carousel-demo-app:nth-child(odd) {
           display: none;
         }
       </style>
@@ -128,5 +132,30 @@
         <div></div>
       </demo-snippet>
     </div>
+
+
+    <div class="vertical-section-container centered">
+      <h3>Basic image-carousel, used inside another polymer element</h3>
+      <demo-snippet>
+        <template>
+          <image-carousel-demo-app aria-labelledby="image-carousel inside another polymer element" images='[
+            "https://c2.staticflickr.com/2/1217/4607963354_e1a8fea210_z.jpg",
+            "https://cs1.livemaster.ru/storage/e6/45/00b119c13ed9f8b4dc6363a60d--materialy-dlya-tvorchestva-nabor-dlya-vyshivki-biserom-belyj-ti.jpg",
+            "https://tse4.mm.bing.net/th?id=ORT.TH_470633631&pid=1.12&eid=G.470633631"]'>
+          </image-carousel-demo-app>
+        </template>
+        <dom-bind>
+          <template>
+            <image-carousel-demo-app aria-labelledby="image-carousel inside another polymer element" images='[
+              "https://c2.staticflickr.com/2/1217/4607963354_e1a8fea210_z.jpg",
+              "https://cs1.livemaster.ru/storage/e6/45/00b119c13ed9f8b4dc6363a60d--materialy-dlya-tvorchestva-nabor-dlya-vyshivki-biserom-belyj-ti.jpg",
+              "https://tse4.mm.bing.net/th?id=ORT.TH_470633631&pid=1.12&eid=G.470633631"]'>
+            </image-carousel-demo-app>            
+          </template>
+        </dom-bind>
+        <div></div>
+      </demo-snippet>
+    </div>
+    
   </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -134,6 +134,7 @@
     </div>
 
 
+
     <div class="vertical-section-container centered">
       <h3>Basic image-carousel, used inside another polymer element</h3>
       <demo-snippet>
@@ -156,6 +157,5 @@
         <div></div>
       </demo-snippet>
     </div>
-    
   </body>
 </html>

--- a/image-carousel.html
+++ b/image-carousel.html
@@ -276,9 +276,7 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
       connectedCallback() {
         super.connectedCallback();
         // recompute number of images when slot contents changes
-        this.shadowRoot.querySelector('slot[attribute="images"]').addEventListener('slotchange', e => {
-            this.computeNumberOfImages();
-        });
+        this.shadowRoot.querySelector('slot[attribute="images"]').addEventListener('slotchange', this.computeNumberOfImages.bind(this));
         this.computeNumberOfImages();
         Polymer.RenderStatus.afterNextRender(this, () => {
           // adding role and tabindex to image carousel
@@ -306,6 +304,14 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
             }
           }
         });
+      }
+
+      /**
+       * The listener on 'slotchange' must be removed to prevent a memory leak.
+       */
+      disconnectedCallback() {
+        super.disconnectedCallback();
+        this.shadowRoot.querySelector('slot[attribute="images"]').removeEventListener('slotchange', this.computeNumberOfImages.bind(this));
       }
 
       /**

--- a/image-carousel.html
+++ b/image-carousel.html
@@ -275,6 +275,10 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
 
       connectedCallback() {
         super.connectedCallback();
+        // recompute number of images when slot contents changes
+        this.shadowRoot.querySelector('slot[attribute="images"]').addEventListener('slotchange', e => {
+            this.computeNumberOfImages();
+        });
         this.computeNumberOfImages();
         Polymer.RenderStatus.afterNextRender(this, () => {
           // adding role and tabindex to image carousel

--- a/image-carousel.html
+++ b/image-carousel.html
@@ -172,6 +172,10 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
      */
 
      class ImageCarousel extends Polymer.GestureEventListeners(Polymer.Element) {
+      constructor() {
+        super();
+        this._slotChangeHandler = this.computeNumberOfImages.bind(this);
+      }
       static get is() { return 'image-carousel'; }
       static get properties() {
         return {
@@ -276,7 +280,7 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
       connectedCallback() {
         super.connectedCallback();
         // recompute number of images when slot contents changes
-        this.shadowRoot.querySelector('slot[attribute="images"]').addEventListener('slotchange', this.computeNumberOfImages.bind(this));
+        this.shadowRoot.querySelector('slot[attribute="images"]').addEventListener('slotchange', this._slotChangeHandler);
         this.computeNumberOfImages();
         Polymer.RenderStatus.afterNextRender(this, () => {
           // adding role and tabindex to image carousel
@@ -311,7 +315,7 @@ this.$['image-carousel'].addEventListener('image-carousel-changed', () => {
        */
       disconnectedCallback() {
         super.disconnectedCallback();
-        this.shadowRoot.querySelector('slot[attribute="images"]').removeEventListener('slotchange', this.computeNumberOfImages.bind(this));
+        this.shadowRoot.querySelector('slot[attribute="images"]').removeEventListener('slotchange', this._slotChangeHandler);
       }
 
       /**

--- a/test/image-carousel_test.html
+++ b/test/image-carousel_test.html
@@ -12,6 +12,7 @@
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="../image-carousel.html">
+  <link rel="import" href="../demo/image-carousel-demo-app.html">
 </head>
 <body>
 
@@ -96,6 +97,22 @@
   </test-fixture>
 
 
+  <test-fixture id="WithinPolymerElementTestFixture">
+    <template>
+      <custom-style>
+        <style>
+          image-carousel {
+            --image-container-mixin: {
+              height: 100px;
+            };
+          }
+        </style>
+      </custom-style>
+      <image-carousel-demo-app></image-carousel-demo-app>
+    </template>
+  </test-fixture>
+
+
   <script>
     suite('image-carousel', function() {
 
@@ -152,6 +169,17 @@
         assert.equal(element.hideDots, false);
         assert.equal(element.hideIcons, true);
         assert.equal(element._hideRightIcon, true);
+        assert.equal(element._hideLeftIcon, true);
+      });
+
+      test('WithinPolymerElementTestFixture', function() {
+        const elementArray = fixture('WithinPolymerElementTestFixture');
+        let element = elementArray[1].$['my-carousel'];
+        assert.equal(element.localName, 'image-carousel');
+        assert.equal(element.autoscroll, false);
+        assert.equal(element.hideDots, false);
+        assert.equal(element.hideIcons, false);
+        assert.equal(element._hideRightIcon, false);
         assert.equal(element._hideLeftIcon, true);
       });
 

--- a/test/image-carousel_test.html
+++ b/test/image-carousel_test.html
@@ -108,7 +108,11 @@
           }
         </style>
       </custom-style>
-      <image-carousel-demo-app></image-carousel-demo-app>
+      <image-carousel-demo-app images='[
+        "https://c2.staticflickr.com/2/1217/4607963354_e1a8fea210_z.jpg",
+        "https://cs1.livemaster.ru/storage/e6/45/00b119c13ed9f8b4dc6363a60d--materialy-dlya-tvorchestva-nabor-dlya-vyshivki-biserom-belyj-ti.jpg",
+        "https://tse4.mm.bing.net/th?id=ORT.TH_470633631&pid=1.12&eid=G.470633631"]'>
+      </image-carousel-demo-app>
     </template>
   </test-fixture>
 
@@ -172,7 +176,7 @@
         assert.equal(element._hideLeftIcon, true);
       });
 
-      test('WithinPolymerElementTestFixture', function() {
+      test('WithinPolymerElementTestFixture', function(done) {
         const elementArray = fixture('WithinPolymerElementTestFixture');
         let element = elementArray[1].$['my-carousel'];
         assert.equal(element.localName, 'image-carousel');
@@ -181,6 +185,14 @@
         assert.equal(element.hideIcons, false);
         assert.equal(element._hideRightIcon, false);
         assert.equal(element._hideLeftIcon, true);
+        /**
+         * Must wait for the dom-repeat to finish, or element._numberOfImages
+         * will be zero.
+         */
+        Polymer.RenderStatus.afterNextRender(element, () => {
+            assert.equal(element._numberOfImages, 3);
+            done();
+        });
       });
 
       test('Selecting element via dot selection', function(done) {


### PR DESCRIPTION
this allows user-defined polymer elements to include an image-carousel, and populate it using dom-repeat.  An element to demonstrate this, image-carousel-demo-app.html, had been added, and demo/index.html updated to show its usage.  

Once this has been accepted & merged, I'll create an additional pull request for a selection notification.